### PR TITLE
Stopped food/partner dialog from showing on every refresh

### DIFF
--- a/assets/js/fp.ui.js
+++ b/assets/js/fp.ui.js
@@ -587,14 +587,17 @@ var fp = {
                             height: 300,
                             width: '15em'
                         };
-
-                        fp.ui.buildDialog(dialogOptions);
+                        if(sessionStorage.getItem('isCustomer') === null)
+                        {
+                            fp.ui.buildDialog(dialogOptions);
+                        }
 
                         $('.welcome_dialog').find('.ui-dialog-titlebar').remove();
                         $('.welcome_dialog .ui-dialog-content').load("assets/views/home/welcome_dialog.php");
                         $('.welcome_dialog .ui-dialog-content').addClass('col-lg-12');
                         $('.welcome_dialog').on('click', '#customers_link', function(e){
                             $('.welcome_dialog .dialog').dialog("close");
+                            sessionStorage.setItem('isCustomer', true);
                             return false;
                         }); 
                         //Handler for menu items


### PR DESCRIPTION
The food or partner dialog showed up every time the page was refreshed, added a key to the sessionStorage to determine whether or not this should pop up or not.
